### PR TITLE
[Agent 1] Frontend UX + brain sanitizer fixes (6 commits)

### DIFF
--- a/RUNWAY.md
+++ b/RUNWAY.md
@@ -7,6 +7,42 @@
 
 ---
 
+## Agent 1 complete — frontend UX + text polish
+
+**Branch:** `feature/frontend-ux-complete` (pushed; draft PR against `dev` open).
+**Scope:** the six deliverables from Don's brief — owned `frontend/**`, `src/brain/sanitizer.py`, and one StepHandoff fix that needed `src/onboarding/handler.py` shape verification (read-only — no changes there).
+
+### What changed (commit-by-commit)
+
+1. `cd68e1b [FIX] brain: sanitizer preserves multi-sentence responses past banned phrases` — substring matching in `_SENTENCE_BANS` was truncating "Hello! How can I assist you today?" to "Hello!". Switched Pass 1 to exact-match-after-normalize so a sentence is stripped only when its substantive content equals a banned phrase verbatim. Standalone openers ("Absolutely!", "Of course.", "Great question!") and bare service offers ("How can I assist?") are still removed; longer responses round-trip intact. Added `tests/unit/test_brain_sanitizer.py` with 11 cases covering the regression, true-opener stripping, and empty/whitespace edges.
+2. `78877e4 [FIX] frontend: home page probes /health and redirects instead of hanging` — `app/page.tsx` now runs its own `GET http://localhost:8767/health` with a 2 s `AbortController` timeout and `router.replace`s to `/chat/` or `/onboarding/1-welcome/` based on `onboarding_complete`. Probe failures default to onboarding so a fresh install with no backend reachable still reaches the wizard within the timeout.
+3. `191c370 [FIX] frontend: wizard Step 5 LLM Continue ships key inline, no Test gate` — BYOK Continue used to refuse unless Test Key had returned `ok` AND the submit payload omitted `key` entirely (so even the gate-lifted submit would have been rejected by the backend). Decoupled Continue from Test Key (Test Key remains as an optional pre-flight affordance), validated non-empty key on Continue, and added `key?: string` to `LlmStepPayload` so the field is typed end-to-end. Backend validates via litellm and writes to keyring atomically — same code path as Test Key, just inlined into the submit.
+4. `025543e [FIX] frontend: wizard StepHandoff submits HANDOFF and redirects to /chat` — the handoff screen subscribed to `ONBOARDING_COMPLETE` but never submitted the HANDOFF step, so `finalize_wizard` never ran and the user was trapped on `/onboarding/8-handoff/` forever. Wired `submitStep(WizardStepId.HANDOFF, {})` on mount, redirect on the submit reply (not the broadcast — broadcasts can be lost across the WS reconnect cycle, see caveats), and kept the broadcast subscriber as a secondary trigger. Added `HandoffStepPayload = Record<string, never>` to the discriminated union; this surfaced a pre-existing inference error in `StepVoice` that I fixed by adding the optional `elevenlabs_configured` flag to `VoiceSettings`.
+5. `1d15800 [FIX] frontend: WS validator no longer rejects bare {type:"pong"} acks` — the strict `isAetherEvent` check required `data` to be an object, which dropped the backend's heartbeat ack `{"type":"pong"}` and triggered a `console.warn` every 25 s. Replaced with a coercer that defaults `data` to `{}` and `timestamp` / `source_module` to safe fallbacks; recognized `pong` inline before dispatch and stamped `lastPongAt`. The 30 s reconnect cycle persists after this change — see caveats.
+6. `5986e56 [UI] welcome + chat empty state + sandbox persona polish` — Welcome subtitle tightened to "Private. Yours. Pick who you want to talk to."; chat empty state subtitle now "Local-first, yours alone. Type when ready." (was "They're running on your machine. Speak freely." — voice-implying); Sandbox → Persona tab gets per-persona `hue` swatches matching the wizard's visual language, active card flexes swatch + name + tagline, footnote rephrased from a docs pointer to actionable guidance.
+
+### What was tested
+
+- `pytest tests/unit/test_brain_sanitizer.py` → 11/11 pass (regression + true-opener + edge).
+- `npm run typecheck` → clean for every file I touched. One pre-existing motion-typing error in `frontend/components/wizard/WizardStepShell.tsx:31` remains (`className` not on `motion.section`'s typed props with the shipped framer-motion version) — not a regression and didn't block dev.
+- `playwright-cli` end-to-end walk against fresh `%LOCALAPPDATA%\aether\aether\` state (deleted `config.yaml` + `wizard_state.yaml`):
+  - `/` → redirected to `/onboarding/1-welcome/` within 2 s ✓
+  - Walked Welcome → Avatar (Aurora) → Personality (Warm & supportive) → Name (default "Aurora") → LLM (BYOK OpenAI, key from `OPENAI_API_KEY` env, **clicked Continue without clicking Test Key**) → Voice (Text only) → Terms (agree) → Finish → handoff → landed in `/chat/` ✓
+  - Sent "Say hello in one sentence." → assistant streamed "Hello! It's great to connect with you." back as a full multi-sentence response (sanitizer no longer truncating at the first `!`) ✓
+  - Backend `/health` after the run: `onboarding_complete: True`, `persona_active: aurora` ✓
+  - Full transcript embedded in the PR description.
+
+### Caveats for the merger
+
+1. **WS reconnect cycle still fires every ~30 s.** Backend log shows clean closes on a 30 s cadence regardless of UI activity, with no app-level message preceding them. Direct Python WS clients (with `websockets` library pings enabled) survive past 90 s against the same backend, which points the cause at the browser side of the connection. My pong-validation fix removed the `console.warn` spam but not the underlying close. I time-boxed the investigation — escalate with Chrome devtools open during the 30 s closure to see whether the close frame originates client-side (and which code dispatches it) or server-side (likely websockets `ping_timeout`). The user-facing impact is small today: each reconnect is sub-second and the heartbeat keeps state coherent, but it WILL race with one-shot broadcasts (e.g., `ONBOARDING_COMPLETE`) — that's why the StepHandoff fix relies on the submit reply rather than the broadcast.
+2. **Frontend `LlmProvider.GUEST` serializes to `"guest"` but the backend expects `"aether_guest"`.** Validators.py line 191 hardcodes the canonical id. Out of scope for this session (the OpenAI BYOK path is the test target and works); fixing it is a one-line frontend rename or a backend alias.
+3. **`StepVoice` ElevenLabs path is still typed loosely.** I added `elevenlabs_configured?: boolean` to `VoiceSettings` to clear the inference error my discriminated union widening introduced; the wizard sends the marker but backend treats voice settings as opaque pass-through. If Agent 2's voice work tightens this contract, revisit.
+4. **Pre-existing `WizardStepShell` motion-typing error is still there.** Not a regression. Either the framer-motion version needs to bump or the `<motion.section>` should be replaced with a typed wrapper. Out of scope for my deliverables.
+5. **No new `EventType` values added.** Per integration contract — kept `WIZARD_STEP_SUBMIT` / `WIZARD_STEP_RESULT` / `ONBOARDING_COMPLETE` / `PERSONA_CHANGED` / `PROVIDER_CHANGED` as the only events I rely on.
+6. **Files touched are limited to my whitelist:** `frontend/**`, `src/brain/sanitizer.py`, `tests/unit/test_brain_sanitizer.py`, `RUNWAY.md` (per the handoff instructions). `src/brain/handler.py`, `src/brain/response_formatter.py`, `src/onboarding/handler.py` were read-only inspection.
+
+---
+
 ## What's proven working
 
 1. **Backend boots** — `.venv/Scripts/python.exe -m src.main` starts health (:8767), WebSocket (:8765), persona loader, memory, brain, onboarding, probe handlers. No import errors, no stale-module references, no Don-specific path assumptions.

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -39,10 +39,10 @@ export default function ChatPage() {
       />
       {messages.length === 0 ? (
         <div className="flex-1 flex items-center justify-center px-6">
-          <div className="text-center">
+          <div className="text-center max-w-md">
             <p className="text-[18px] text-fg-secondary">Say hi to {assistantLabel}.</p>
             <p className="mt-2 text-[13px] text-fg-muted">
-              They're running on your machine. Speak freely.
+              Local-first, yours alone. Type when ready.
             </p>
           </div>
         </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,26 +2,64 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useSessionStore } from "@/lib/stores/session";
 
 /**
  * Routing gate. Static export can't redirect server-side, so we render a
  * tiny placeholder and push on the client as soon as the bootstrap probe
  * has decided whether onboarding is needed.
+ *
+ * The probe runs locally rather than going through the session store so a
+ * slow or down backend never traps the user on this page — we always fall
+ * through to the wizard within PROBE_TIMEOUT_MS, on the assumption that a
+ * user landing on `/` with no backend reachable is most likely a fresh
+ * install with onboarding still pending.
  */
+const HEALTH_URL = "http://localhost:8767/health";
+const PROBE_TIMEOUT_MS = 2_000;
+
+async function probeOnboardingComplete(): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    const resp = await fetch(HEALTH_URL, {
+      signal: controller.signal,
+      cache: "no-store",
+    });
+    clearTimeout(timer);
+    if (!resp.ok) return false;
+    const payload: unknown = await resp.json();
+    return extractOnboardingFlag(payload);
+  } catch {
+    return false;
+  }
+}
+
+function extractOnboardingFlag(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") return false;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.onboarding_complete === "boolean") return p.onboarding_complete;
+  const config = p.config;
+  if (config && typeof config === "object") {
+    const c = config as Record<string, unknown>;
+    if (typeof c.onboarding_complete === "boolean") return c.onboarding_complete;
+  }
+  return false;
+}
+
 export default function Home() {
   const router = useRouter();
-  const ready = useSessionStore((s) => s.onboardingCheckPerformed);
-  const onboarded = useSessionStore((s) => s.onboardingComplete);
 
   useEffect(() => {
-    if (!ready) return;
-    if (onboarded) {
-      router.replace("/chat/");
-    } else {
-      router.replace("/onboarding/1-welcome/");
-    }
-  }, [ready, onboarded, router]);
+    let cancelled = false;
+    void (async () => {
+      const onboarded = await probeOnboardingComplete();
+      if (cancelled) return;
+      router.replace(onboarded ? "/chat/" : "/onboarding/1-welcome/");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
 
   return (
     <div className="h-full w-full flex items-center justify-center text-fg-muted text-sm">

--- a/frontend/app/sandbox/page.tsx
+++ b/frontend/app/sandbox/page.tsx
@@ -78,14 +78,20 @@ function PersonaTab() {
   };
   const current = activeId ? findPersona(activeId) : undefined;
   return (
-    <Section title="Persona packs" subtitle="Switch between bundled personas. Custom packs can be created later.">
-      <div className="mb-6 p-4 rounded-[var(--radius-md)] bg-bg-2 border border-border-subtle">
-        <div className="text-[11px] uppercase tracking-[0.14em] text-fg-muted">Active</div>
-        <div className="mt-1 text-[15px] font-medium">
-          {current?.displayName ?? "None selected"}
-        </div>
-        <div className="text-[12px] text-fg-muted mt-1">
-          {current?.tagline ?? "Pick one below to start talking."}
+    <Section
+      title="Persona packs"
+      subtitle={`Switch between bundled personas. ${PERSONAS.length} loaded.`}
+    >
+      <div className="mb-6 p-4 rounded-[var(--radius-md)] bg-bg-2 border border-border-subtle flex items-center gap-4">
+        <PersonaSwatch hue={current?.hue ?? 0} initial={current?.displayName?.[0] ?? "—"} size={40} />
+        <div className="min-w-0">
+          <div className="text-[11px] uppercase tracking-[0.14em] text-fg-muted">Active</div>
+          <div className="mt-1 text-[15px] font-medium truncate">
+            {current?.displayName ?? "None selected"}
+          </div>
+          <div className="text-[12px] text-fg-muted mt-1 truncate">
+            {current?.tagline ?? "Pick one below to start talking."}
+          </div>
         </div>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
@@ -95,23 +101,42 @@ function PersonaTab() {
             type="button"
             onClick={() => switchPersona(p.id)}
             className={[
-              "text-left p-3 rounded-md border transition-colors duration-150",
+              "text-left p-3 rounded-md border transition-colors duration-150 flex items-start gap-3",
               activeId === p.id
                 ? "border-accent bg-accent/5 text-fg-primary"
                 : "border-border-subtle hover:border-border-strong bg-bg-2 text-fg-secondary",
             ].join(" ")}
           >
-            <div className="text-[13px] font-medium">{p.displayName}</div>
-            <div className="text-[11px] text-fg-muted mt-0.5">{p.tagline}</div>
+            <PersonaSwatch hue={p.hue} initial={p.displayName[0] ?? "?"} size={28} />
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium">{p.displayName}</div>
+              <div className="text-[11px] text-fg-muted mt-0.5">{p.tagline}</div>
+            </div>
           </button>
         ))}
       </div>
       <p className="text-[12px] text-fg-muted mt-6">
-        Create new personas in{" "}
-        <code className="text-fg-secondary">docs/PERSONA-SCHEMA.md</code>. User packs live under{" "}
-        <code className="text-fg-secondary">%APPDATA%/aether/personas/</code>.
+        Drop a custom pack into <code className="text-fg-secondary">%APPDATA%/aether/personas/</code> and it'll show up here on next launch.
       </p>
     </Section>
+  );
+}
+
+function PersonaSwatch({ hue, initial, size }: { hue: number; initial: string; size: number }) {
+  return (
+    <div
+      aria-hidden
+      className="rounded-full flex items-center justify-center shrink-0 text-fg-primary font-medium"
+      style={{
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.42),
+        background: `radial-gradient(60% 60% at 30% 30%, hsl(${hue} 65% 60%) 0%, hsl(${hue} 55% 30%) 70%)`,
+        boxShadow: "var(--shadow-raised)",
+      }}
+    >
+      {initial.toUpperCase()}
+    </div>
   );
 }
 

--- a/frontend/components/wizard/StepHandoff.tsx
+++ b/frontend/components/wizard/StepHandoff.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getWsClient } from "@/lib/ws";
 import { EventType, WizardStepId } from "@/lib/types";
@@ -25,8 +25,11 @@ const TASKS: readonly { id: string; label: string }[] = [
 export function StepHandoff() {
   const router = useRouter();
   const resetWizard = useWizardStore((s) => s.resetAll);
+  const submitStep = useWizardStore((s) => s.submitStep);
   const setOnboardingComplete = useSessionStore((s) => s.setOnboardingComplete);
   const [doneIdx, setDoneIdx] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const submittedRef = useRef(false);
 
   useEffect(() => {
     if (doneIdx >= TASKS.length) return;
@@ -46,12 +49,46 @@ export function StepHandoff() {
     return unsub;
   }, [resetWizard, router, setOnboardingComplete]);
 
+  // Fire the HANDOFF submit exactly once on mount. The backend re-validates
+  // every prior step, calls finalize_wizard (writes config.yaml + sets
+  // onboarding_complete=true), then sends WIZARD_STEP_RESULT and broadcasts
+  // ONBOARDING_COMPLETE in that order. We redirect on the submit reply
+  // because subscribing to ONBOARDING_COMPLETE alone is racy: the WS may
+  // bounce between the reply and the broadcast and lose the one-shot event.
+  // The ONBOARDING_COMPLETE subscriber above stays as a secondary trigger.
+  // The HMR-safe ref guard keeps Strict Mode's double-invoke from sending
+  // two submits.
+  useEffect(() => {
+    if (submittedRef.current) return;
+    submittedRef.current = true;
+    void (async () => {
+      const result = await submitStep(WizardStepId.HANDOFF, {});
+      if (result.success) {
+        setOnboardingComplete(true);
+        resetWizard();
+        router.replace("/chat/");
+      } else {
+        setError(result.error ?? "Could not finalize setup. Try again.");
+        // Allow a retry by resetting the guard.
+        submittedRef.current = false;
+      }
+    })();
+  }, [submitStep, setOnboardingComplete, resetWizard, router]);
+
   return (
     <WizardStepShell
       step={WizardStepId.HANDOFF}
       title="Setting things up."
       subtitle="One moment. We'll drop you into the chat as soon as everything's ready."
     >
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 px-4 py-2 rounded-md border border-error/50 bg-error/10 text-error text-[12px]"
+        >
+          {error}
+        </div>
+      )}
       <ol className="space-y-3 max-w-md">
         {TASKS.map((task, idx) => {
           const complete = idx < doneIdx;

--- a/frontend/components/wizard/StepLlm.tsx
+++ b/frontend/components/wizard/StepLlm.tsx
@@ -179,13 +179,14 @@ export function StepLlm() {
       setError("Ollama isn't reachable. Install it or pick a different option.");
       return;
     }
-    if (selected === "byok" && keyTestState !== "ok") {
-      setError("Test your API key before continuing.");
+    if (selected === "byok" && !apiKey.trim()) {
+      setError("Enter an API key for the selected provider.");
       return;
     }
 
     let provider: LlmProvider;
     let tierMap: LlmTierMap;
+    let key: string | undefined;
     if (selected === "local") {
       provider = LlmProvider.OLLAMA;
       tierMap = {
@@ -198,6 +199,7 @@ export function StepLlm() {
       const fallback = DEFAULT_TIERS[LlmProvider.ANTHROPIC];
       if (!fallback) throw new Error("Missing default tier map for fallback");
       tierMap = DEFAULT_TIERS[byokProvider] ?? fallback;
+      key = apiKey.trim();
     } else {
       provider = LlmProvider.GUEST;
       const fallback = DEFAULT_TIERS[LlmProvider.ANTHROPIC];
@@ -210,6 +212,7 @@ export function StepLlm() {
       const result = await submitStep(WizardStepId.LLM, {
         llm_provider: provider,
         llm_tier_map: tierMap,
+        ...(key ? { key } : {}),
       });
       if (result.success) router.push("/onboarding/6-voice/");
       else if (result.error) setError(result.error);

--- a/frontend/components/wizard/StepWelcome.tsx
+++ b/frontend/components/wizard/StepWelcome.tsx
@@ -30,7 +30,7 @@ export function StepWelcome() {
     <WizardStepShell
       step={WizardStepId.WELCOME}
       title="Meet your AI companion."
-      subtitle="Aether runs on your computer. Private. Yours. Choose who you want to talk to."
+      subtitle="Private. Yours. Pick who you want to talk to."
       footer={
         <div className="flex-1 flex justify-end">
           <Button size="lg" onClick={handleStart} isLoading={busy}>

--- a/frontend/lib/stores/wizard.ts
+++ b/frontend/lib/stores/wizard.ts
@@ -66,6 +66,12 @@ export interface TermsStepPayload {
   accepted_terms_at: string;
   telemetry: TelemetryPrefs;
 }
+/**
+ * Handoff carries no user input. The backend re-validates that all prior
+ * steps completed, then calls `finalize_wizard` and broadcasts
+ * ONBOARDING_COMPLETE. Frontend just needs to fire the submit on mount.
+ */
+export type HandoffStepPayload = Record<string, never>;
 
 export type WizardStepPayload =
   | WelcomeStepPayload
@@ -74,7 +80,8 @@ export type WizardStepPayload =
   | NameStepPayload
   | LlmStepPayload
   | VoiceStepPayload
-  | TermsStepPayload;
+  | TermsStepPayload
+  | HandoffStepPayload;
 
 export interface WizardStepResult {
   success: boolean;

--- a/frontend/lib/stores/wizard.ts
+++ b/frontend/lib/stores/wizard.ts
@@ -50,6 +50,13 @@ export interface LlmStepPayload {
   llm_provider: LlmProvider;
   llm_tier_map: LlmTierMap;
   llm_model_overrides?: Record<string, string>;
+  /**
+   * BYOK API key. Sent to backend on submit so it can validate via litellm
+   * and forward to the OS keyring. Never stored in the wizard store and
+   * never persisted to disk on the frontend — gone from memory the moment
+   * `submitStep` resolves.
+   */
+  key?: string;
 }
 export interface VoiceStepPayload {
   voice_mode: VoiceMode;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -171,6 +171,13 @@ export interface LlmTierMap {
 export interface VoiceSettings {
   elevenlabs_voice_id?: string;
   device?: string;
+  /**
+   * Marker the wizard sets when the ElevenLabs API key has been written to
+   * the OS keyring during BYOK setup. The backend keeps it on the wizard
+   * state but never reads its value — presence in `voice_settings` is the
+   * sole signal a key was provided.
+   */
+  elevenlabs_configured?: boolean;
 }
 
 export interface TelemetryPrefs {

--- a/frontend/lib/ws.ts
+++ b/frontend/lib/ws.ts
@@ -62,6 +62,7 @@ export function createWsClient(opts: CreateWsClientOptions): WsClient {
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let intentionallyClosed = false;
+  let lastPongAt = 0;
   const outbox: string[] = [];
 
   const subscribers = new Map<AnyEventType, Set<EventHandler>>();
@@ -191,11 +192,23 @@ export function createWsClient(opts: CreateWsClientOptions): WsClient {
         console.error("[ws] malformed JSON frame", err, msg.data);
         return;
       }
-      if (!isAetherEvent(parsed)) {
+      // Heartbeat acks: backend replies to {"type":"ping"} with the bare
+      // {"type":"pong"} (no data, no timestamp) — handle inline and skip the
+      // dispatcher so the strict event shape doesn't reject it as garbage.
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        (parsed as { type?: unknown }).type === "pong"
+      ) {
+        lastPongAt = Date.now();
+        return;
+      }
+      const event = coerceAetherEvent(parsed);
+      if (!event) {
         console.warn("[ws] frame did not match AetherEvent shape", parsed);
         return;
       }
-      dispatch(parsed);
+      dispatch(event);
     };
 
     next.onerror = (ev: Event) => {
@@ -291,10 +304,35 @@ export function createWsClient(opts: CreateWsClientOptions): WsClient {
   return { connect, disconnect, send, subscribe, onStatusChange, getStatus };
 }
 
-function isAetherEvent(value: unknown): value is AetherEvent {
-  if (value === null || typeof value !== "object") return false;
+/**
+ * Coerce a parsed inbound frame into an AetherEvent, defaulting `data` to
+ * `{}` when missing or non-object. The strict shape (data must be an object)
+ * was rejecting valid backend frames that omit `data` for trivial replies
+ * (e.g., the bare `{"type":"pong"}` heartbeat ack), spamming console.warn
+ * every 25s. Returning a default-shaped event keeps subscribers honest
+ * without losing the type.
+ */
+function coerceAetherEvent(value: unknown): AetherEvent | null {
+  if (value === null || typeof value !== "object") return null;
   const candidate = value as Record<string, unknown>;
-  return typeof candidate.type === "string" && typeof candidate.data === "object" && candidate.data !== null;
+  if (typeof candidate.type !== "string" || !candidate.type) return null;
+  const data =
+    candidate.data && typeof candidate.data === "object"
+      ? (candidate.data as Record<string, unknown>)
+      : {};
+  // request_id isn't on AetherEvent's TS type but the runtime carries it as
+  // a passthrough field on `data` when present (server.py copies it there
+  // during broadcast). Subscribers that need it read `event.data.request_id`.
+  return {
+    type: candidate.type as AnyEventType,
+    data,
+    timestamp:
+      typeof candidate.timestamp === "number"
+        ? candidate.timestamp
+        : Date.now() / 1000,
+    source_module:
+      typeof candidate.source_module === "string" ? candidate.source_module : "backend",
+  };
 }
 
 /* -----------------------------------------------------------------------

--- a/src/brain/sanitizer.py
+++ b/src/brain/sanitizer.py
@@ -93,14 +93,29 @@ _LINE_BANS = [
     re.compile(r"^\s*(?:what can i do for you|how can i help)\s*[?!.]?\s*$", re.IGNORECASE),
 ]
 
-# Compiled sentence ban patterns for speed
-_SENTENCE_BAN_PATTERNS = [re.compile(re.escape(phrase), re.IGNORECASE) for phrase in _SENTENCE_BANS]
+# Set of banned phrases for exact-match lookup (after sentence normalization).
+# Substring matching was too aggressive: "How can I assist you today?" would be
+# stripped because it contained the banned fragment "how can i assist", even
+# though the full sentence is a perfectly normal response. We now strip a
+# sentence only when its substantive content equals a banned phrase verbatim
+# (case-insensitive, with surrounding whitespace and trailing punctuation
+# removed). Tone shaping for longer responses belongs in the system prompt.
+_SENTENCE_BAN_SET: frozenset[str] = frozenset(_SENTENCE_BANS)
+_TRAILING_SENTENCE_PUNCT = "?!.,;:"
+
+
+def _normalize_sentence(sentence: str) -> str:
+    """Lowercase, trim whitespace, strip trailing punctuation."""
+    return sentence.lower().strip().rstrip(_TRAILING_SENTENCE_PUNCT).strip()
 
 
 def sanitize_response(text: str) -> str:
     """Remove banned phrases from LLM response.
 
-    Pass 1: Sentence-level — remove any sentence containing a banned phrase.
+    Pass 1: Sentence-level — remove a sentence only if its substantive content
+            (lowercased, trimmed, trailing punctuation removed) equals a banned
+            phrase verbatim. This preserves multi-sentence responses where a
+            banned fragment merely appears as part of a longer sentence.
     Pass 2: Line-level — remove entire lines matching line ban patterns.
     Pass 3: Clean up artifacts (double spaces, orphan punctuation, blank lines).
     """
@@ -119,20 +134,10 @@ def sanitize_response(text: str) -> str:
         sentences = re.split(r"(?<=[.!?])\s+", line)
         kept_sentences = []
         for sentence in sentences:
-            sentence_lower = sentence.lower().strip()
-            # Check if any banned phrase appears in this sentence
-            is_banned = False
-            for pattern in _SENTENCE_BAN_PATTERNS:
-                if pattern.search(sentence_lower):
-                    is_banned = True
-                    break
-
-            # Also check for standalone "Absolutely!" / "Of course!" / "Certainly!" at start
-            if sentence_lower.rstrip("!.") in ("absolutely", "of course", "certainly", "sure thing"):
-                is_banned = True
-
-            if not is_banned:
-                kept_sentences.append(sentence)
+            normalized = _normalize_sentence(sentence)
+            if normalized and normalized in _SENTENCE_BAN_SET:
+                continue
+            kept_sentences.append(sentence)
 
         cleaned_lines.append(" ".join(kept_sentences))
 

--- a/tests/unit/test_brain_sanitizer.py
+++ b/tests/unit/test_brain_sanitizer.py
@@ -1,0 +1,72 @@
+"""Tests for src/brain/sanitizer.py.
+
+The sanitizer should remove obviously-bad standalone sentences (compliment
+openers, over-eager openings, formal closings) WITHOUT truncating multi-
+sentence responses where a banned fragment appears mid-sentence.
+
+The regression case: previously, "Hello! How can I assist you today?" was being
+truncated to "Hello!" because Pass 1 substring-matched "how can i assist"
+inside the second sentence. The sanitizer must now preserve such responses.
+"""
+
+from src.brain.sanitizer import sanitize_response
+
+
+class TestRoundTrip:
+    """Multi-sentence responses with embedded service phrases must survive."""
+
+    def test_hello_followed_by_service_offer_round_trips(self):
+        # The exact failure case from the integration session.
+        text = "Hello! How can I assist you today?"
+        assert sanitize_response(text) == text
+
+    def test_paragraph_with_let_me_know_mid_sentence(self):
+        text = "The capital of France is Paris. Let me know if you want some history."
+        # First sentence kept; second is a "let me know if..." construction
+        # that line-level cleanup also matches — but only when it begins the
+        # line. Here it begins a NEW sentence on the same line, so the line-
+        # level patterns don't fire (they anchor on line start, not sentence).
+        result = sanitize_response(text)
+        assert "Paris" in result
+        assert "Paris." in result
+
+    def test_long_response_with_want_me_to_phrase(self):
+        text = "Sure, the API uses JSON. Want me to look up the auth endpoint for you?"
+        result = sanitize_response(text)
+        # The sentence is longer than the banned phrase — must survive.
+        assert "auth endpoint" in result
+
+
+class TestStripsTrueOpeners:
+    """Standalone openers should still be stripped."""
+
+    def test_strips_standalone_absolutely(self):
+        assert sanitize_response("Absolutely!") == ""
+
+    def test_strips_standalone_of_course(self):
+        assert sanitize_response("Of course.") == ""
+
+    def test_strips_standalone_great_question(self):
+        assert sanitize_response("Great question!") == ""
+
+    def test_strips_standalone_service_offer(self):
+        # "How can I assist?" alone is just filler.
+        assert sanitize_response("How can I assist?") == ""
+
+    def test_strips_opener_keeps_following_content(self):
+        text = "Absolutely! The capital of France is Paris."
+        result = sanitize_response(text)
+        assert "Absolutely" not in result
+        assert "Paris" in result
+
+
+class TestEmptyAndWhitespace:
+    def test_empty_string(self):
+        assert sanitize_response("") == ""
+
+    def test_whitespace_only(self):
+        assert sanitize_response("   \n  ") == "   \n  "
+
+    def test_no_banned_content(self):
+        text = "The Eiffel Tower is 330 meters tall."
+        assert sanitize_response(text) == text


### PR DESCRIPTION
## Summary

Agent 1 — frontend UX completion + two text-polish bugs. Six commits, all atomic, on `feature/frontend-ux-complete` off `dev`.

- `[FIX] brain: sanitizer preserves multi-sentence responses past banned phrases` — substring matching truncated `"Hello! How can I assist you today?"` to `"Hello!"`. Switched to exact-match-after-normalize. Tests added.
- `[FIX] frontend: home page probes /health and redirects instead of hanging` — `app/page.tsx` runs its own probe with a 2 s timeout, no longer waits on the session-store bootstrap.
- `[FIX] frontend: wizard Step 5 LLM Continue ships key inline, no Test gate` — Continue used to be blocked by Test Key + the submit payload omitted `key`. Both fixed.
- `[FIX] frontend: wizard StepHandoff submits HANDOFF and redirects to /chat` — handoff screen never submitted the step, so `finalize_wizard` never ran. Wired the submit on mount; redirects on the submit reply (broadcasts can race the WS reconnect cycle).
- `[FIX] frontend: WS validator no longer rejects bare {type:"pong"} acks` — heartbeat ack was being dropped by the strict shape check; replaced with a coercer that defaults missing fields. **30 s reconnect cycle still observed** — see RUNWAY caveat 1.
- `[UI] welcome + chat empty state + sandbox persona polish` — Welcome subtitle tightened; chat empty state no longer implies voice; Sandbox → Persona tab gets per-persona `hue` swatches matching the wizard.
- `[DOCS] RUNWAY: Agent 1 frontend-UX + sanitizer handoff`

## Test plan

- [x] `pytest tests/unit/test_brain_sanitizer.py` → 11/11 pass
- [x] `npm run typecheck` clean for every file touched (one pre-existing motion-typing error in `WizardStepShell.tsx` remains — not a regression)
- [x] Fresh `%LOCALAPPDATA%\aether\aether\` state, walked the wizard end-to-end via playwright-cli with OpenAI BYOK, landed in `/chat`, sent "Say hello in one sentence." → got full streamed response back ("Hello! It's great to connect with you.") — sanitizer round-trip proven on the live path.
- [ ] WS 5-min idle survives without reconnect storms — **NOT MET**, see RUNWAY caveat 1. Heartbeat ack noise eliminated; underlying close cycle unresolved without Chrome devtools access.

## playwright-cli E2E transcript

```
=== Aether E2E Transcript — 2026-04-17 21:11:47 ===

--- Step 0: Open root, expect redirect to wizard 1 ---
- Page URL: http://127.0.0.1:3000/
After 4s:  - Page URL: http://127.0.0.1:3000/onboarding/1-welcome/

--- Step 1: Welcome → click Get started ---
click ref=e47 (Get started)
→ Page URL: http://127.0.0.1:3000/onboarding/2-avatar/

--- Step 2: Avatar → pick Aurora, Continue ---
click ref=e72 (Aurora)
click ref=e170 (Continue)
→ Page URL: http://127.0.0.1:3000/onboarding/3-personality/

--- Step 3: Personality → pick Warm & supportive, Continue ---
click ref=e198 (Warm & supportive)
click ref=e284 (Continue)
→ Page URL: http://127.0.0.1:3000/onboarding/4-name/

--- Step 4: Name → keep default Aurora, Continue ---
click ref=e310 (Continue, name pre-filled 'Aurora')
→ Page URL: http://127.0.0.1:3000/onboarding/5-llm/

--- Step 5: LLM → BYOK card, OpenAI, fill key, Continue WITHOUT Test Key ---
click ref=e333 (BYOK card)
select ref=e354 value='openai'
fill ref=e358 value='$OPENAI_API_KEY' (redacted)
click ref=e344 (Continue — no Test Key first)
→ Page URL: http://127.0.0.1:3000/onboarding/6-voice/  (elapsed 13s — backend validated key via litellm)

--- Step 6: Voice → pick Text only, Continue ---
click ref=e402 (Text only)
click ref=e408 (Continue)
→ Page URL: http://127.0.0.1:3000/onboarding/7-terms/

--- Step 7: Terms → tick agree, Finish setup ---
click ref=e452 (agreement label)
click ref=e455 (Finish setup)
→ Page URL: http://127.0.0.1:3000/chat/

--- Step 8: Handoff (auto-submits, redirects to /chat) ---
→ Page URL: http://127.0.0.1:3000/chat/

--- Chat: send 'Say hello in one sentence.' ---
fill ref=e473 value='Say hello in one sentence.'
click ref=e474 (Send)
→ Aurora response (full text round-trip): "Hello! It's great to connect with you."

--- Backend state after E2E ---
  onboarding_complete: True
  persona_active:     aurora
  modules:            {'core': 'ready', 'personas': 'ready', 'voice': 'pending_onboarding', 'avatar': 'pending_onboarding', 'websocket_server': 'ready'}

--- Backend log: WIZARD/ONBOARDING/finalize events (selected) ---
21:12:51 INFO  src.shared.secrets: Stored API key for provider='openai' in OS keyring
21:13:29 INFO  src.onboarding.finalizer: Wrote onboarded config to ...\config.yaml
21:13:29 INFO  src.onboarding.finalizer: ChromaDB collection ready for persona='aurora'
21:13:29 INFO  src.onboarding.state: Wizard state cleared
21:13:29 INFO  src.onboarding.finalizer: Onboarding finalized — installation_id=d8eb80d9-..., persona=aurora, provider=openai, voice=off
21:13:41 INFO  src.brain.handler: brain: processing (26 chars, mode=text)
```

## Caveats for the merger

See RUNWAY.md "Agent 1 complete" section for the full set. Headline items:

1. **WS reconnect cycle every ~30 s persists** after the heartbeat fix. Backend logs clean closes; direct Python WS clients survive 90 s+; cause is browser-side and needs Chrome devtools to isolate. Sub-second reconnects don't break UX today but DO race one-shot broadcasts (which is why StepHandoff redirects on the submit reply, not the broadcast).
2. **`LlmProvider.GUEST` serializes to `"guest"` but backend expects `"aether_guest"`.** Out of scope for this session (OpenAI BYOK is the test target); needs a one-line frontend rename or backend alias.
3. Pre-existing `WizardStepShell` framer-motion typing error remains. Not a regression.
4. No new `EventType` values added — kept the integration contract intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)